### PR TITLE
Add test badge

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,7 +4,7 @@ on:
       - main
       - master
 
-name: pkgdown
+name: docs
 
 jobs:
   pkgdown:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,6 +1,6 @@
 on: [push, pull_request]
 
-name: test_coverage
+name: build
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,87 @@ dataFiles
 docs
 articles
 
+# ignore path
+/bak
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# make dependency files
+*.d
+
+# emacs backup files
+*~
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Hector logs
+logs/*.*
+*.log
+
+# OS-specific files
+.DS_Store
+.Trashes
+*.swp
+
+# Xcode build directories, schemes, and interface state
+*.lock
+*.xccheckout
+*~.nib
+build/
+DerivedData/
+xcodeuserstate
+xcuserdata
+project.xcworkspace/
+
+# Project files
+project_files/*.*
+Release
+ipch
+Run Test Cases
+Debug
+libs
+project_files/visual_studio/
+project_files/VS/*.*
+libs/
+*.kdev4
+*.sdf
+*.suo
+
+# Output
+output/output*
+
+# R
+.Rhistory
+R/batchrunner/*.pdf
+R/batchrunner/*.csv
+.Rapp.history
+.Rproj.user
+.RData
+inst/doc
+
+# vignette caches
+/vignettes/*_cache
+
+# Rstudio connect files
+rsconnect
+inst/shinyApp/temp.ini
+inst/shinyApp/test.ini
+packrat/lib*/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!-- badges: start -->
    ![R-CMD](https://github.com/JGCRI/rmap/workflows/R-CMD/badge.svg)
-  [![codecov](https://codecov.io/gh/JGCRI/rmap/branch/main/graph/badge.svg?token=XQ913U4IYM)](https://codecov.io/gh/JGCRI/rmap)
+  [![codecov](https://codecov.io/gh/JGCRI/rmap/branch/main/graph/badge.svg?token=XQ913U4IYM)](https://codecov.io/gh/JGCRI/rmap) ![build](https://github.com/JGCRI/rmap/workflows/test_coverage/badge.svg) ![docs](https://github.com/JGCRI/rmap/workflows/pkgdown/badge.svg)
+  
   <!-- badges: end -->
 
 <!-- ------------------------>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- badges: start -->
    ![R-CMD](https://github.com/JGCRI/rmap/workflows/R-CMD/badge.svg)
-  [![codecov](https://codecov.io/gh/JGCRI/rmap/branch/main/graph/badge.svg?token=XQ913U4IYM)](https://codecov.io/gh/JGCRI/rmap) ![build](https://github.com/JGCRI/rmap/workflows/test_coverage/badge.svg) ![docs](https://github.com/JGCRI/rmap/workflows/pkgdown/badge.svg)
+  [![codecov](https://codecov.io/gh/JGCRI/rmap/branch/main/graph/badge.svg?token=XQ913U4IYM)](https://codecov.io/gh/JGCRI/rmap) ![build](https://github.com/JGCRI/rmap/workflows/build/badge.svg) ![docs](https://github.com/JGCRI/rmap/workflows/docs/badge.svg)
   
   <!-- badges: end -->
 


### PR DESCRIPTION
This PR addresses the following:

- Make `.gitignore` more robust
- Change the names of the `test_coverage` and `pkgdown` workflows; not file names, but workflow names.  This will enable the ability to create a descriptive badge name in the README.  
- Added badges for `build` and `docs` in the README.  The `docs` badge will not be active until it goes into the main.
